### PR TITLE
fix: resolve port following a specific order

### DIFF
--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -64,7 +64,7 @@ Ambiorix <- R6::R6Class(
     },
     #' @details Cache templates in memory instead of reading
     #' them from disk.
-    cache_templates = \(){
+    cache_templates = function() {
       .globals$cache_tmpls <- TRUE
       invisible(self)
     },

--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -196,6 +196,8 @@ Ambiorix <- R6::R6Class(
       if(is.null(host))
         host <- private$.host
 
+      port <- get_port(host, port)
+
       super$prepare()
       private$.routes <- super$get_routes()
       private$.receivers <- super$get_receivers()

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,18 +59,27 @@ check_installed <- function(pkg){
     stop(sprintf("This function requires the package {%s}", pkg), call. = FALSE)
 }
 
-#' Retrieve Port
+#' Retrieve the Port for Server Binding
 #'
-#' Retrieve the port to use.
+#' Determines the appropriate port for the server, following a
+#' specific order of precedence.
 #'
-#' @param port Input port, optional.
+#' @param host String. The host address to bind to when selecting a random port.
+#' @param port Integer. An optional input port, provided by the user.
+#' @details The port to use is resolved in the following order of precedence:
+#' 1. Forced Port Option: Typically used by Belgic, the load balancer. If
+#'   the `ambiorix.port.force` R option is specified, this port is returned.
+#'   This option should not be altered during development.
+#' 2. `AMBIORIX_PORT` environment variable
+#' 3. `port` argument.
+#' 4. `SHINY_PORT` environment variable.
+#' 5. Random port.
 #'
-#' @return A port number.
+#' @return Integer. Port value to bind the server.
 #'
 #' @noRd
 #' @keywords internal
 get_port <- function(host, port = NULL){
-
   # we need to override the port if the load balancer
   # is running. This should NOT be set by a dev
   # this ensures we can overwrite
@@ -78,8 +87,19 @@ get_port <- function(host, port = NULL){
   if(!is.null(forced))
     return(forced)
 
-  if(!is.null(port))
+  has_ints_only <- function(x) !grepl(pattern = "\\D", x = x)
+  is_valid_port <- function(x) !is.null(x) && !identical(x, "") && has_ints_only(x)
+
+  ambiorix_port <- Sys.getenv("AMBIORIX_PORT")
+  if (is_valid_port(ambiorix_port))
+    return(as.integer(ambiorix_port))
+
+  if (is_valid_port(port))
     return(as.integer(port))
+
+  shiny_port <- Sys.getenv("SHINY_PORT")
+  if (is_valid_port(shiny_port))
+    return(as.integer(shiny_port))
 
   httpuv::randomPort(host = host)
 }


### PR DESCRIPTION
closes #72 

port to bind server on is now resolved in the following order of precedence:
1. `ambiorix.port.force` R option (for belgic)
2. `AMBIORIX_PORT` env var
3. `port` argument (provided by user)
4. `SHINY_PORT` env var (for shiny server et. al)
5. random port