### PR TITLE
ft: improve handling of shiny and htmltools tags

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -113,7 +113,7 @@ Response <- R6::R6Class(
       deprecated_headers(headers)
       deprecated_status(status)
       headers <- private$.get_headers(headers)
-      response(status = private$.get_status(status), headers = headers, body = convert_body(body))
+      response(status = private$.get_status(status), headers = headers, body = body)
     },
     #' @details Send a plain HTML response, pre-processed with sprintf.
     #' @param body Body of the response.
@@ -125,7 +125,7 @@ Response <- R6::R6Class(
       deprecated_status(status)
       body <- sprintf(body, ...)
       headers <- private$.get_headers(headers)
-      response(status = private$.get_status(status), headers = headers, body = convert_body(body))
+      response(status = private$.get_status(status), headers = headers, body = body)
     },
     #' @details Send a plain text response.
     #' @param body Body of the response.
@@ -136,7 +136,7 @@ Response <- R6::R6Class(
       deprecated_status(status)
       headers <- private$.get_headers(headers)
       headers[["Content-Type"]] <- content_plain()
-      response(status = private$.get_status(status), headers = headers, body = convert_body(body))
+      response(status = private$.get_status(status), headers = headers, body = body)
     },
     #' @details Send a file.
     #' @param file File to send.

--- a/R/response.R
+++ b/R/response.R
@@ -56,16 +56,13 @@ convert_body <- function(body) {
   if(inherits(body, "AsIs"))
     return(body)
 
-  if(is.raw(body))
-    return(body)
-
-  if(is.character(body) && length(body) == 1L)
-    return(body)
-
-  if(is.factor(body) || inherits(body, "shiny.tag"))
+  if (is.factor(body))
     return(as.character(body))
 
-  return(body)
+  if(inherits(body, "shiny.tag") || inherits(body, "shiny.tag.list"))
+    return(htmltools::doRenderTags(body))
+
+  body
 }
 
 #' Construct Response


### PR DESCRIPTION
closes #76 & #77 

- remove redundant calls to `convert_body()` in the Response methods: `send()`, `sendf()` and `text()`
-  refactor `convert_body()` by removing unnecessary checks
- improve handling of shiny & htmltools tags

with this PR, this reprex now works as expected:

```r
# app.R
library(ambiorix)
library(htmltools)

app <- Ambiorix$new()

app$get("/", \(req, res){
  x <- tagList(
    tags$h1("hello"),
    tags$h2("there")
  )
  res$send(x)
})

app$start()
```