### PR TITLE
ch: handle continual processing of requests using httpuv

### DIFF
--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -263,10 +263,8 @@ Ambiorix <- R6::R6Class(
         self$stop()
       })
 
-      # keep R "alive"
-      while (TRUE) {
-        httpuv::service()
-      }
+      # continually process requests:
+      httpuv::service(timeoutMs = Inf)
 
       invisible(self)
     },


### PR DESCRIPTION
closes #97 

here's a minimal reprex for testing purposes:

```r
devtools::load_all()
library(htmltools)

page_links <- \() {
  Map(
    f = \(href, label) {
      tags$a(href = href, label)
    },
    c("/", "/about", "/contact"),
    c("Home", "About", "Contact")
  )
}

home_get <- \(req, res) {
  html <- tagList(
    page_links(),
    tags$h3("hello, world!")
  )
  res$send(html)
}

about_get <- \(req, res) {
  html <- tagList(
    page_links(),
    tags$h3("About Us")
  )
  res$send(html)
}

contact_get <- \(req, res) {
  html <- tagList(
    page_links(),
    tags$h3("Get In Touch!")
  )
  res$send(html)
}

app <- Ambiorix$new()
app$get("/", home_get)
app$get("/about", about_get)
app$get("/contact", contact_get)
app$start()
```