### PR TITLE
ch: remove as_label()

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -326,7 +326,7 @@ Response <- R6::R6Class(
       cli::cli_end()
     },
     #' @details Set Data
-    #' @param name Name of the variable.
+    #' @param name String. Name of the variable.
     #' @param value Value of the variable.
     #' @return Invisible returns self.
     set = function(name, value){
@@ -338,13 +338,11 @@ Response <- R6::R6Class(
         "Deprecated. The environment is no longer locked, you may simply `res$name <- value`"
       )
 
-      name <- as_label(name)
       self[[name]] <- value
-
       invisible(self)
     },
     #' @details Get data
-    #' @param name Name of the variable to get.
+    #' @param name String. Name of the variable to get.
     get = function(name){
       assert_that(not_missing(name))
       .Deprecated(
@@ -353,16 +351,15 @@ Response <- R6::R6Class(
         "Deprecated. The environment is no longer locked, you may simply `req$value"
       )
 
-      name <- as_label(name)
       self[[name]]
     },
     #' @details Add headers to the response.
-    #' @param name,value Name and value of the header.
+    #' @param name String. Name of the header.
+    #' @param value Value of the header.
     #' @return Invisibly returns self.
     header = function(name, value){
       assert_that(not_missing(name))
       assert_that(not_missing(value))
-      name <- as_label(name)
       private$.headers[[name]] <- value
       invisible(self)
     },
@@ -500,7 +497,7 @@ Response <- R6::R6Class(
     },
     #' @details Set a cookie
     #' Overwrites existing cookie of the same `name`.
-    #' @param name Name of the cookie.
+    #' @param name String. Name of the cookie.
     #' @param value value of the cookie.
     #' @param expires Expiry, if an integer assumes it's the number of seconds
     #' from now. Otherwise accepts an object of class `POSIXct` or `Date`.
@@ -554,7 +551,6 @@ Response <- R6::R6Class(
         }
       }
 
-      name <- as_label(name)
       private$.cookies[[name]] <- cookie(
         name,
         value,

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,25 +104,6 @@ get_port <- function(host, port = NULL){
   httpuv::randomPort(host = host)
 }
 
-#' Make label
-#' 
-#' Cheap replacement for rlang::as_label to avoid dependency.
-#' Must fix.
-#' 
-#' @noRd
-#' @keywords internal
-as_label <- function(x) {
-  name <- tryCatch(
-    is.character(x),
-    error = function(e) e
-  )
-
-  if(!inherits(name, "error"))
-    return(x)
-
-  deparse(substitute(x, parent.frame()))
-}
-
 #' Silent readLines
 #' 
 #' Avoids EOF warnings.

--- a/man/Response.Rd
+++ b/man/Response.Rd
@@ -458,7 +458,7 @@ Print
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name}}{Name of the variable.}
+\item{\code{name}}{String. Name of the variable.}
 
 \item{\code{value}}{Value of the variable.}
 }
@@ -483,7 +483,7 @@ Invisible returns self.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name}}{Name of the variable to get.}
+\item{\code{name}}{String. Name of the variable to get.}
 }
 \if{html}{\out{</div>}}
 }
@@ -503,7 +503,9 @@ Get data
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name, value}}{Name and value of the header.}
+\item{\code{name}}{String. Name of the header.}
+
+\item{\code{value}}{Value of the header.}
 }
 \if{html}{\out{</div>}}
 }
@@ -769,7 +771,7 @@ Invisible returns self.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name}}{Name of the cookie.}
+\item{\code{name}}{String. Name of the cookie.}
 
 \item{\code{value}}{value of the cookie.}
 


### PR DESCRIPTION
closes #103 

- remove definition & usage of `as_label()`
- update documentation of methods of the Response class which used `as_label()` to explicitly state that `name` is expected to be a string.