### PR TITLE
ch: remove syntactic sugar to improve backward compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Encoding: UTF-8
 LazyData: false
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Depends: R (>= 4.1.0)
 Imports:
     fs,
     log,

--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -121,7 +121,7 @@ Ambiorix <- R6::R6Class(
     #' 
     #' @examples 
     #' # my custom error handler:
-    #' error_handler <- \(req, res, error) {
+    #' error_handler <- function(req, res, error) {
     #'   if (!is.null(error)) {
     #'     error_msg <- conditionMessage(error)
     #'     cli::cli_alert_danger("Error: {error_msg}")
@@ -136,7 +136,7 @@ Ambiorix <- R6::R6Class(
     #' }
     #'
     #' # handler for GET at /whoami:
-    #' whoami <- \(req, res) {
+    #' whoami <- function(req, res) {
     #'   # simulate error (object 'Pikachu' is not defined)
     #'   print(Pikachu)
     #' }

--- a/R/cookie.R
+++ b/R/cookie.R
@@ -90,7 +90,7 @@ is_cookie_parser <- function(obj) {
 #' `value`.
 #' 
 #' @examples 
-#' func <- \(name, value, ...) {
+#' func <- function(name, value, ...) {
 #'  sprintf("prefix.%s", value)
 #' }
 #' 

--- a/R/log.R
+++ b/R/log.R
@@ -6,7 +6,7 @@
 #' @noRd 
 #' @keywords internal
 logPredicate <- function(log){
-  \() log
+  function() log
 }
 
 #' Logger
@@ -83,21 +83,21 @@ set_log_error <- function(log) {
 #' CLI Symbols for log
 #' 
 #' @keywords internal
-success <- \() {
+success <- function() {
   cli::col_green(cli::symbol$tick)
 }
 
 #' @keywords internal
-error <- \() {
+error <- function() {
   cli::col_red(cli::symbol$cross)
 }
 
 #' @keywords internal
-info <- \() {
+info <- function() {
   cli::col_blue(cli::symbol$info)
 }
 
 #' @keywords internal
-warn <- \() {
+warn <- function() {
   cli::col_yellow(cli::symbol$warning)
 }

--- a/R/parser.R
+++ b/R/parser.R
@@ -37,9 +37,9 @@
 #'   library(htmltools)
 #'   library(readxl)
 #'
-#'   page_links <- \() {
+#'   page_links <- function() {
 #'     Map(
-#'       f = \(href, label) {
+#'       f = function(href, label) {
 #'         tags$a(href = href, label)
 #'       },
 #'       c("/", "/about", "/contact"),
@@ -47,7 +47,7 @@
 #'     )
 #'   }
 #'
-#'   forms <- \() {
+#'   forms <- function() {
 #'     form1 <- tags$form(
 #'       action = "/url-form-encoded",
 #'       method = "POST",
@@ -79,7 +79,7 @@
 #'     tagList(form1, form2)
 #'   }
 #'
-#'   home_get <- \(req, res) {
+#'   home_get <- function(req, res) {
 #'     html <- tagList(
 #'       page_links(),
 #'       tags$h3("hello, world!"),
@@ -89,7 +89,7 @@
 #'     res$send(html)
 #'   }
 #'
-#'   home_post <- \(req, res) {
+#'   home_post <- function(req, res) {
 #'     body <- parse_json(req)
 #'     cat(strrep(x = "-", times = 10), "\n")
 #'     cat("Parsed JSON:\n")
@@ -103,7 +103,7 @@
 #'     res$json(response)
 #'   }
 #'
-#'   url_form_encoded_post <- \(req, res) {
+#'   url_form_encoded_post <- function(req, res) {
 #'     body <- parse_form_urlencoded(req)
 #'     cat(strrep(x = "-", times = 8), "\n")
 #'     cat("Parsed application/x-www-form-urlencoded:\n")
@@ -112,7 +112,7 @@
 #'
 #'     list_items <- lapply(
 #'       X = names(body),
-#'       FUN = \(nm) {
+#'       FUN = function(nm) {
 #'         tags$li(
 #'           nm,
 #'           ":",
@@ -131,12 +131,12 @@
 #'     res$send(html)
 #'   }
 #'
-#'   multipart_form_data_post <- \(req, res) {
+#'   multipart_form_data_post <- function(req, res) {
 #'     body <- parse_multipart(req)
 #'
 #'     list_items <- lapply(
 #'       X = names(body),
-#'       FUN = \(nm) {
+#'       FUN = function(nm) {
 #'         field <- body[[nm]]
 #'
 #'         # if 'field' is a file, parse it & print on console:
@@ -155,11 +155,11 @@
 #'         }
 #'
 #'         if (is_csv) {
-#'           read.csv(file = file_path) |> print()
+#'           print(read.csv(file = file_path))
 #'         }
 #'
 #'         if (is_xlsx) {
-#'           readxl::read_xlsx(path = file_path) |> print()
+#'           print(readxl::read_xlsx(path = file_path))
 #'         }
 #'
 #'         tags$li(
@@ -180,7 +180,7 @@
 #'     res$send(html)
 #'   }
 #'
-#'   about_get <- \(req, res) {
+#'   about_get <- function(req, res) {
 #'     html <- tagList(
 #'       page_links(),
 #'       tags$h3("About Us")
@@ -188,7 +188,7 @@
 #'     res$send(html)
 #'   }
 #'
-#'   contact_get <- \(req, res) {
+#'   contact_get <- function(req, res) {
 #'     html <- tagList(
 #'       page_links(),
 #'       tags$h3("Get In Touch!")

--- a/R/render.R
+++ b/R/render.R
@@ -7,7 +7,7 @@
 #' @param dir Directory of file from which `content` originates.
 #' 
 #' @keywords internal
-replace_partials <- \(content, dir) {
+replace_partials <- function(content, dir) {
   content <- apply_replace_partial(content, dir)
 
   if(any(grepl("\\[! .* !\\]", content)))
@@ -25,7 +25,7 @@ replace_partials <- \(content, dir) {
 #' @param dir Base directory.
 #' 
 #' @keywords internal
-replace_partial <- \(line, dir) {
+replace_partial <- function(line, dir) {
   if(length(line) > 1)
     line <- apply_replace_partial(line, dir)
 
@@ -70,7 +70,7 @@ replace_partial <- \(line, dir) {
 #' @param file File to retrieve directory from.
 #' 
 #' @keywords internal
-get_dir <- \(file) {
+get_dir <- function(file) {
   dirname(normalizePath(file))
 }
 
@@ -81,7 +81,7 @@ get_dir <- \(file) {
 #' @inheritParams replace_partials
 #' 
 #' @keywords internal
-apply_replace_partial <- \(content, dir) {
+apply_replace_partial <- function(content, dir) {
   unlist(
     unname(
       sapply(content, replace_partial, dir)
@@ -194,7 +194,7 @@ use_html_template <- function() {
 #' @param data Data to render, a `list`.
 #' 
 #' @keywords internal
-render_tags <- \(lines, data){
+render_tags <- function(lines, data){
   new_lines <- c()
   n <- 0L
   str <- ""

--- a/R/render.R
+++ b/R/render.R
@@ -45,8 +45,7 @@ replace_partial <- \(line, dir) {
     line
   ) 
 
-  path <- gsub("\\[!|!\\]", "", line) |> 
-    trimws()
+  path <- trimws(gsub("\\[!|!\\]", "", line))
 
   # construct new base directory
   new_dir <- dirname(path)
@@ -72,8 +71,7 @@ replace_partial <- \(line, dir) {
 #' 
 #' @keywords internal
 get_dir <- \(file) {
-  normalizePath(file) |> 
-    dirname()
+  dirname(normalizePath(file))
 }
 
 #' Replace Partial Vectorised
@@ -84,9 +82,11 @@ get_dir <- \(file) {
 #' 
 #' @keywords internal
 apply_replace_partial <- \(content, dir) {
-  sapply(content, replace_partial, dir) |> 
-    unname() |> 
-    unlist()
+  unlist(
+    unname(
+      sapply(content, replace_partial, dir)
+    )
+  )
 }
 
 #' R Object
@@ -117,9 +117,7 @@ robj <- function(obj){
 print.robj <- function(x, ...){
   cli::cli_alert_info("R object")
   class(x) <- class(x)[!class(x) %in% "robj"]
-  x |> 
-    dput() |> 
-    print()
+  print(dput(x))
 }
 
 #' JSON Object
@@ -138,8 +136,7 @@ jobj <- function(obj) {
 #' @export
 print.jobj <- function(x, ...){
   cli::cli_alert_info("JSON object")
-  serialise(x, ...) |> 
-    print()
+  print(serialise(x, ...))
 }
 
 #' Pre Hook Response

--- a/R/response.R
+++ b/R/response.R
@@ -628,8 +628,7 @@ Response <- R6::R6Class(
           if(!inherits(x, "jobj"))
             return(x)
 
-          serialise(x) |> 
-            as.character()
+          as.character(serialise(x))
         })
       }
 

--- a/R/response.R
+++ b/R/response.R
@@ -624,7 +624,7 @@ Response <- R6::R6Class(
       file_content <- replace_partials(file_content, get_dir(file))
 
       if(ext == "html") {
-        data <- lapply(data, \(x) {
+        data <- lapply(data, function(x) {
           if(!inherits(x, "jobj"))
             return(x)
 

--- a/R/routing.R
+++ b/R/routing.R
@@ -331,12 +331,14 @@ Routing <- R6::R6Class(
     get_routes = function(routes = list(), parent = ""){
       routes <- append(
         routes, 
-        private$.routes |>
-          lapply(\(route) {
+        lapply(
+          private$.routes,
+          function(route) {
             route$route$as_pattern(parent)
             route$route$decompose(parent)
             route
-          })
+          }
+        )
       )
 
       if(!length(private$.routers)) return(routes)
@@ -368,11 +370,13 @@ Routing <- R6::R6Class(
     get_middleware = function(middlewares = list(), parent = ""){
       middlewares <- append(
         middlewares,
-        private$.middleware |>
-          lapply(\(fn) {
+        lapply(
+          private$.middleware, 
+          function(fn) {
             attr(fn, "basepath") <- paste0(parent, private$.basepath) 
             return(fn)
-          })
+          }
+        )
       )
 
       if(!length(private$.routers)) return(middlewares)

--- a/man/Ambiorix.Rd
+++ b/man/Ambiorix.Rd
@@ -62,7 +62,7 @@ if(interactive())
 ## ------------------------------------------------
 
 # my custom error handler:
-error_handler <- \(req, res, error) {
+error_handler <- function(req, res, error) {
   if (!is.null(error)) {
     error_msg <- conditionMessage(error)
     cli::cli_alert_danger("Error: {error_msg}")
@@ -77,7 +77,7 @@ error_handler <- \(req, res, error) {
 }
 
 # handler for GET at /whoami:
-whoami <- \(req, res) {
+whoami <- function(req, res) {
   # simulate error (object 'Pikachu' is not defined)
   print(Pikachu)
 }
@@ -323,7 +323,7 @@ Sets the error handler.
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{# my custom error handler:
-error_handler <- \(req, res, error) {
+error_handler <- function(req, res, error) {
   if (!is.null(error)) {
     error_msg <- conditionMessage(error)
     cli::cli_alert_danger("Error: {error_msg}")
@@ -338,7 +338,7 @@ error_handler <- \(req, res, error) {
 }
 
 # handler for GET at /whoami:
-whoami <- \(req, res) {
+whoami <- function(req, res) {
   # simulate error (object 'Pikachu' is not defined)
   print(Pikachu)
 }

--- a/man/as_cookie_preprocessor.Rd
+++ b/man/as_cookie_preprocessor.Rd
@@ -16,7 +16,7 @@ as the \code{cookie} method of the \link{Response} class
 Identifies a function as a cookie preprocessor.
 }
 \examples{
-func <- \(name, value, ...) {
+func <- function(name, value, ...) {
  sprintf("prefix.\%s", value)
 }
 

--- a/man/parse_form_urlencoded.Rd
+++ b/man/parse_form_urlencoded.Rd
@@ -40,9 +40,9 @@ if (interactive()) {
   library(htmltools)
   library(readxl)
 
-  page_links <- \() {
+  page_links <- function() {
     Map(
-      f = \(href, label) {
+      f = function(href, label) {
         tags$a(href = href, label)
       },
       c("/", "/about", "/contact"),
@@ -50,7 +50,7 @@ if (interactive()) {
     )
   }
 
-  forms <- \() {
+  forms <- function() {
     form1 <- tags$form(
       action = "/url-form-encoded",
       method = "POST",
@@ -82,7 +82,7 @@ if (interactive()) {
     tagList(form1, form2)
   }
 
-  home_get <- \(req, res) {
+  home_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("hello, world!"),
@@ -92,7 +92,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  home_post <- \(req, res) {
+  home_post <- function(req, res) {
     body <- parse_json(req)
     cat(strrep(x = "-", times = 10), "\n")
     cat("Parsed JSON:\n")
@@ -106,7 +106,7 @@ if (interactive()) {
     res$json(response)
   }
 
-  url_form_encoded_post <- \(req, res) {
+  url_form_encoded_post <- function(req, res) {
     body <- parse_form_urlencoded(req)
     cat(strrep(x = "-", times = 8), "\n")
     cat("Parsed application/x-www-form-urlencoded:\n")
@@ -115,7 +115,7 @@ if (interactive()) {
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         tags$li(
           nm,
           ":",
@@ -134,12 +134,12 @@ if (interactive()) {
     res$send(html)
   }
 
-  multipart_form_data_post <- \(req, res) {
+  multipart_form_data_post <- function(req, res) {
     body <- parse_multipart(req)
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         field <- body[[nm]]
 
         # if 'field' is a file, parse it & print on console:
@@ -158,11 +158,11 @@ if (interactive()) {
         }
 
         if (is_csv) {
-          read.csv(file = file_path) |> print()
+          print(read.csv(file = file_path))
         }
 
         if (is_xlsx) {
-          readxl::read_xlsx(path = file_path) |> print()
+          print(readxl::read_xlsx(path = file_path))
         }
 
         tags$li(
@@ -183,7 +183,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  about_get <- \(req, res) {
+  about_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("About Us")
@@ -191,7 +191,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  contact_get <- \(req, res) {
+  contact_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("Get In Touch!")

--- a/man/parse_json.Rd
+++ b/man/parse_json.Rd
@@ -43,9 +43,9 @@ if (interactive()) {
   library(htmltools)
   library(readxl)
 
-  page_links <- \() {
+  page_links <- function() {
     Map(
-      f = \(href, label) {
+      f = function(href, label) {
         tags$a(href = href, label)
       },
       c("/", "/about", "/contact"),
@@ -53,7 +53,7 @@ if (interactive()) {
     )
   }
 
-  forms <- \() {
+  forms <- function() {
     form1 <- tags$form(
       action = "/url-form-encoded",
       method = "POST",
@@ -85,7 +85,7 @@ if (interactive()) {
     tagList(form1, form2)
   }
 
-  home_get <- \(req, res) {
+  home_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("hello, world!"),
@@ -95,7 +95,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  home_post <- \(req, res) {
+  home_post <- function(req, res) {
     body <- parse_json(req)
     cat(strrep(x = "-", times = 10), "\n")
     cat("Parsed JSON:\n")
@@ -109,7 +109,7 @@ if (interactive()) {
     res$json(response)
   }
 
-  url_form_encoded_post <- \(req, res) {
+  url_form_encoded_post <- function(req, res) {
     body <- parse_form_urlencoded(req)
     cat(strrep(x = "-", times = 8), "\n")
     cat("Parsed application/x-www-form-urlencoded:\n")
@@ -118,7 +118,7 @@ if (interactive()) {
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         tags$li(
           nm,
           ":",
@@ -137,12 +137,12 @@ if (interactive()) {
     res$send(html)
   }
 
-  multipart_form_data_post <- \(req, res) {
+  multipart_form_data_post <- function(req, res) {
     body <- parse_multipart(req)
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         field <- body[[nm]]
 
         # if 'field' is a file, parse it & print on console:
@@ -161,11 +161,11 @@ if (interactive()) {
         }
 
         if (is_csv) {
-          read.csv(file = file_path) |> print()
+          print(read.csv(file = file_path))
         }
 
         if (is_xlsx) {
-          readxl::read_xlsx(path = file_path) |> print()
+          print(readxl::read_xlsx(path = file_path))
         }
 
         tags$li(
@@ -186,7 +186,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  about_get <- \(req, res) {
+  about_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("About Us")
@@ -194,7 +194,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  contact_get <- \(req, res) {
+  contact_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("Get In Touch!")

--- a/man/parse_multipart.Rd
+++ b/man/parse_multipart.Rd
@@ -49,9 +49,9 @@ if (interactive()) {
   library(htmltools)
   library(readxl)
 
-  page_links <- \() {
+  page_links <- function() {
     Map(
-      f = \(href, label) {
+      f = function(href, label) {
         tags$a(href = href, label)
       },
       c("/", "/about", "/contact"),
@@ -59,7 +59,7 @@ if (interactive()) {
     )
   }
 
-  forms <- \() {
+  forms <- function() {
     form1 <- tags$form(
       action = "/url-form-encoded",
       method = "POST",
@@ -91,7 +91,7 @@ if (interactive()) {
     tagList(form1, form2)
   }
 
-  home_get <- \(req, res) {
+  home_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("hello, world!"),
@@ -101,7 +101,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  home_post <- \(req, res) {
+  home_post <- function(req, res) {
     body <- parse_json(req)
     cat(strrep(x = "-", times = 10), "\n")
     cat("Parsed JSON:\n")
@@ -115,7 +115,7 @@ if (interactive()) {
     res$json(response)
   }
 
-  url_form_encoded_post <- \(req, res) {
+  url_form_encoded_post <- function(req, res) {
     body <- parse_form_urlencoded(req)
     cat(strrep(x = "-", times = 8), "\n")
     cat("Parsed application/x-www-form-urlencoded:\n")
@@ -124,7 +124,7 @@ if (interactive()) {
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         tags$li(
           nm,
           ":",
@@ -143,12 +143,12 @@ if (interactive()) {
     res$send(html)
   }
 
-  multipart_form_data_post <- \(req, res) {
+  multipart_form_data_post <- function(req, res) {
     body <- parse_multipart(req)
 
     list_items <- lapply(
       X = names(body),
-      FUN = \(nm) {
+      FUN = function(nm) {
         field <- body[[nm]]
 
         # if 'field' is a file, parse it & print on console:
@@ -167,11 +167,11 @@ if (interactive()) {
         }
 
         if (is_csv) {
-          read.csv(file = file_path) |> print()
+          print(read.csv(file = file_path))
         }
 
         if (is_xlsx) {
-          readxl::read_xlsx(path = file_path) |> print()
+          print(readxl::read_xlsx(path = file_path))
         }
 
         tags$li(
@@ -192,7 +192,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  about_get <- \(req, res) {
+  about_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("About Us")
@@ -200,7 +200,7 @@ if (interactive()) {
     res$send(html)
   }
 
-  contact_get <- \(req, res) {
+  contact_get <- function(req, res) {
     html <- tagList(
       page_links(),
       tags$h3("Get In Touch!")

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -3,40 +3,40 @@ test_that("application", {
 
   app <- Ambiorix$new()
 
-  app$get("/", \(req, res) {
+  app$get("/", function(req, res) {
     res$send("home")
   })
 
-  app$post("/", \(req, res) {
+  app$post("/", function(req, res) {
     res$send("home")
   })
   
-  app$put("/", \(req, res) {
+  app$put("/", function(req, res) {
     res$send("home")
   })
 
-  app$patch("/", \(req, res) {
+  app$patch("/", function(req, res) {
     res$send("home")
   })
 
-  app$delete("/", \(req, res) {
+  app$delete("/", function(req, res) {
     res$send("home")
   })
 
-  app$all("/", \(req, res) {
+  app$all("/", function(req, res) {
     res$send("home")
   })
 
-  app$options("/", \(req, res) {
+  app$options("/", function(req, res) {
     res$send("home")
   })
 
   # dynamic
-  app$get("/.path", \(req, res) {
+  app$get("/.path", function(req, res) {
     res$send("home")
   })
 
-  app$receive("message", \(...) {
+  app$receive("message", function(...) {
     print("received")
   })
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -22,13 +22,13 @@ test_that("Ambiorix", {
   expect_equal(app$host, "127.0.0.1")
 
   expect_error(app$set_404("error"))
-  expect_error(app$set_404(\(req) {}))
-  expect_s3_class(app$set_404(\(req, res) {
+  expect_error(app$set_404(function(req) {}))
+  expect_s3_class(app$set_404(function(req, res) {
     res$send("Errr")
   }), "Ambiorix")
 
   expect_error(app$serialiser("error"))
-  expect_s3_class(app$serialiser(\(data) {
+  expect_s3_class(app$serialiser(function(data) {
     return("data")
   }), "Ambiorix")
 

--- a/tests/testthat/test-cookie.R
+++ b/tests/testthat/test-cookie.R
@@ -33,7 +33,7 @@ test_that("Request cookie", {
   )
 
   # parser
-  fn <- \(req) {
+  fn <- function(req) {
     return(req$HTTP_COOKIE)
   }
   expect_false(is_cookie_parser(fn))
@@ -72,7 +72,7 @@ test_that("Request cookie", {
   )
 
   # preprocessor
-  .fn <- \(name, value, ...){
+  .fn <- function(name, value, ...){
     sprintf("prefix.%s", value)
   }
   prep <- as_cookie_preprocessor(.fn)

--- a/tests/testthat/test-response.R
+++ b/tests/testthat/test-response.R
@@ -43,7 +43,7 @@ test_that("Response", {
     htmltools::p("hello")
   )
   expect_equal(resp$body, htmltools::HTML("<p>hello</p>"))
-  
+
   # factor
   resp <- res$send(as.factor("hello"))
   expect_equal(resp$body, "hello")
@@ -99,8 +99,8 @@ test_that("Response", {
   # json
   resp <- res$json(list(1, 2))
   expect_equal(
-    resp$body, 
-    serialise(list(1,2))
+    resp$body,
+    serialise(list(1, 2))
   )
   expect_equal(
     resp$headers[["Content-Type"]],
@@ -139,10 +139,10 @@ test_that("Response", {
   # png
   img <- "logo.png"
   resp <- res$png(img)
-  response <- resp$body |> 
-    head() |> 
-    as.character() |> 
-    paste0(collapse = "")
+  response <- paste0(
+    as.character(head(resp$body)),
+    collapse = ""
+  )
   expect_equal(
     response,
     "89504e470d0a"
@@ -150,10 +150,10 @@ test_that("Response", {
 
   # image
   resp <- res$image(img)
-  response <- resp$body |> 
-    head() |> 
-    as.character() |> 
-    paste0(collapse = "")
+  response <- paste0(
+    as.character(head(resp$body)),
+    collapse = ""
+  )
   expect_equal(
     response,
     "89504e470d0a"
@@ -164,10 +164,10 @@ test_that("Response", {
   # ggplot2
   plot <- ggplot2::ggplot(cars)
   resp <- res$ggplot2(plot)
-  response <- resp$body |> 
-    head() |> 
-    as.character() |> 
-    paste0(collapse = "")
+  response <- paste0(
+    as.character(head(resp$body)),
+    collapse = ""
+  )
   expect_equal(
     response,
     "89504e470d0a"

--- a/tests/testthat/test-route.R
+++ b/tests/testthat/test-route.R
@@ -1,8 +1,5 @@
 test_that("Route", {
-
-  r <- Route$new(
-    path = "/:id"
-  )
+  r <- Route$new(path = "/:id")$decompose()$as_pattern()
 
   expect_true(r$dynamic)
   expect_equal(r$pattern, "^/[[:alnum:][:space:][:punct:]]*$")

--- a/tests/testthat/test-router.R
+++ b/tests/testthat/test-router.R
@@ -5,40 +5,40 @@ test_that("rlication", {
 
   r <- Router$new("/users")
 
-  r$get("/", \(req, res) {
+  r$get("/", function(req, res) {
     res$send("home")
   })
 
-  r$post("/", \(req, res) {
+  r$post("/", function(req, res) {
     res$send("home")
   })
   
-  r$put("/", \(req, res) {
+  r$put("/", function(req, res) {
     res$send("home")
   })
 
-  r$patch("/", \(req, res) {
+  r$patch("/", function(req, res) {
     res$send("home")
   })
 
-  r$delete("/", \(req, res) {
+  r$delete("/", function(req, res) {
     res$send("home")
   })
 
-  r$all("/", \(req, res) {
+  r$all("/", function(req, res) {
     res$send("home")
   })
 
-  r$options("/", \(req, res) {
+  r$options("/", function(req, res) {
     res$send("home")
   })
 
   # dynamic
-  r$get("/.path", \(req, res) {
+  r$get("/.path", function(req, res) {
     res$send("home")
   })
 
-  r$receive("message", \(...) {
+  r$receive("message", function(...) {
     print("received")
   })
 

--- a/tests/testthat/test-websocket.R
+++ b/tests/testthat/test-websocket.R
@@ -1,6 +1,6 @@
 test_that("Websocket", {
   expect_error(WebsocketHandler$new())
-  ws <- WebsocketHandler$new("hello", \(msg) {
+  ws <- WebsocketHandler$new("hello", function(msg) {
     return(msg)
   })
   msg <- ws$receive(list(message = "world"))


### PR DESCRIPTION
closes #112 

1. replace usage of the pipe with nested function calls
2. use long-hand function notation instead of `\() {}`
3. remove dependency on R >= 4.1.0 from the DESCRIPTION file