### PR TITLE
htmltools rendering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R:
            email = "jcoenep@gmail.com",
            comment = c(ORCID = "0000-0002-6637-4107")),
     person(family = "Opifex", role = c("fnd")),
-    person(given = "Kennedy", family = "Mwavu", role = "ctb", comment = c(ORCID = "0009-0006-3157-7234"))
+    person(given = "Kennedy", family = "Mwavu", role = "ctb", comment = c(ORCID = "0009-0006-3157-7234")),
+    person(given = "Julio", family = "Collazos", role = "ctb", comment = c(ORCID = "0009-0006-5503-0997"))
   )
 Description: A web framework inspired by 'express.js' to build
   any web service from multi-page websites to 'RESTful' 

--- a/R/response.R
+++ b/R/response.R
@@ -160,10 +160,10 @@ render_htmltools <- function(x) {
   href_deps <- grep("http", strsplit(rendered_deps, "\n")[[1]], value = TRUE)
   href_deps <- paste0(href_deps, collapse = "\n")
 
-  # add encoding and dependencies
-  q$closest("html")$find("head")$append(htmltools::tags$meta(charset = "UTF-8"))
-  q$closest("html")$find("head")$append(htmltools::HTML(href_deps))
-  q$closest("html")$find("head")$append(inline_deps)
+  # add encoding and dependencies for the first selected tag this avoid duplicates as append *appends* for each selected tag
+  q$closest("html")$find("head")$filter(function(x,i)i==1)$append(htmltools::tags$meta(charset = "UTF-8"))
+  q$closest("html")$find("head")$filter(function(x,i)i==1)$append(htmltools::HTML(href_deps))
+  q$closest("html")$find("head")$filter(function(x,i)i==1)$append(inline_deps)
 
   # get all tags and render
   x <- q$allTags()

--- a/R/response.R
+++ b/R/response.R
@@ -130,15 +130,6 @@ render_htmltools <- function(x) {
   if(!length(q$closest("html")$selectedTags()))
     return(htmltools::renderTags(x)$html)
   
-  html_attr <- if(!length(x$attribs)){
-    ""
-  } else {
-    attribs_vals <- unlist(x$attribs)
-    attribs_vals <- gsub(
-      "=NA\\b", "", paste0(names(attribs_vals), "=", attribs_vals, collapse = " ")
-    )
-  }
-
   deps <- htmltools::resolveDependencies(
     dependencies = htmltools::findDependencies(x)
   )
@@ -165,24 +156,13 @@ render_htmltools <- function(x) {
   q$closest("html")$find("head")$filter(function(x,i)i==1)$append(htmltools::HTML(href_deps))
   q$closest("html")$find("head")$filter(function(x,i)i==1)$append(inline_deps)
 
+  # add placeholder for head tag children
+  q$closest("html")$prepend(htmltools::HTML("<head>\n<!--HEAD_CONTENT-->\n</head>"))
   # get all tags and render
   x <- q$allTags()
   rendered <- htmltools::renderTags(x)
-  bodyTag <- as.character(Find(f = function(s)s$name=="body",x$children))
 
-  paste0(
-    c(
-      "<!DOCTYPE html>",
-      sprintf("<html %s>", html_attr),
-      "<head>",
-      rendered$head,
-      "</head>",
-      bodyTag, 
-      "</html>"
-    ),
-    collapse = "\n"
-  )
-
+  paste0("<!DOCTYPE html>\n",sub("<!--HEAD_CONTENT-->",rendered$head, rendered$html, fixed = TRUE))
 }
 
 #' @export


### PR DESCRIPTION
Hi there
Currently `htmltools` tags are rendered using `doRenderTags`, if I'm not mistaken. This prevents us from using render hooks, as stated by [htmltools website](https://rstudio.github.io/htmltools/reference/renderTags.html):

>doRenderTags is intended for very low-level use; it ignores render hooks, singletons, head, and dependency handling, and simply renders the given tag objects as HTML. Please use renderTags() if x has not already handled its dependencies and render hooks.

https://github.com/ambiorix-web/ambiorix/blob/ad6c3bff42d38b9b806415e2fffb52c1b9426b07/R/response.R#L131

https://github.com/ambiorix-web/ambiorix/blob/ad6c3bff42d38b9b806415e2fffb52c1b9426b07/R/response.R#L156


This PR is an attempt to render htmltools tags with `renderTags()`.

Also, when multiple head tags are used (probably by mistake) the current approach would cause the dependencies to be added multiple times which could result in unexpected results.

Example:

```r
library(ambiorix)
library(htmltools)
library(DT)
app <- Ambiorix$new()
app$get("/", \(req, res){
  html_to_send <- tags$html(
    tags$body(
      tags$div(
        tags$div(
          "TRUE?",
          .renderHook = \(s){
            if (TRUE) {
              tagAppendAttributes(s, class = "TRUE") |>
                tagAppendChild(
                  child = tags$div("TRUE")
                )
            }
          }
        )
        ,DT::datatable(iris)
      )
    ),
    tags$head(
      tags$script("// A script")
    ),
    tags$head(
      tags$script("// A second script")
    ),
    lang = "en"
  )
  res$send(html_to_send)
})
app$start()
```
Executing this leads to:

### Current Approach

![image](https://github.com/user-attachments/assets/0a323cd5-94ad-456a-8460-a9b7c5cb6dad)

Also, the render hooks are not evaluated

### PR Approach

![image](https://github.com/user-attachments/assets/35232f83-1e31-45ae-87c3-a072efe95f19)

